### PR TITLE
Improve the way to build the application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.o
 *.a
 *.so
+website-controller
 
 # Folders
 _obj

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM scratch
-MAINTAINER marko.luksa@gmail.com
+LABEL org.opencontainers.image.authors="marko.luksa@gmail.com"
 ADD website-controller /
 ADD deployment-template.json /
 ADD service-template.json /

--- a/Dockerfile.Build
+++ b/Dockerfile.Build
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+
+##
+## Build
+##
+FROM golang:1.16-buster AS build
+LABEL org.opencontainers.image.authors="marko.luksa@gmail.com"
+
+WORKDIR /
+
+COPY pkg pkg
+COPY Makefile go.mod ./
+RUN make
+
+##
+## Deploy
+##
+FROM scratch
+LABEL org.opencontainers.image.authors="marko.luksa@gmail.com"
+COPY --from=build website-controller /
+ADD deployment-template.json service-template.json /
+CMD ["/website-controller"]

--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@ A barely working example of a Kubernetes controller, which watches the Kubernete
 
 NOTE: This is not the correct way to create a Kubernetes controller, as it simply performs a watch request in a loop. This will never work properly, because some watch events will be lost. 
 
+## How to build the application?
+
+***Requirements:*** Docker already installed and started on your environment.
+
+For linux OS with Go already installed, you can build the application with the `make` command. You can also build the application and create the docker image with `luksa/website-controller` as name and `latest` as tag directly using the `make image` command. Finally, you can build the application, create the docker image and push it directly in a docker registry with the command `make push`.
+
+
+For all other OS and Linux without Go installed, you can build the application and create the docker image with `luksa/website-controller` as name and `latest` as tag, using the command `docker build . -f Dockerfile.Build -t luksa/website-controller`. In this case, the application is built while creating the docker image.

--- a/deployment-template.json
+++ b/deployment-template.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "extensions/v1beta1",
+  "apiVersion": "apps/v1",
   "kind": "Deployment",
   "metadata": {
     "name": "[NAME]",
@@ -9,6 +9,11 @@
   },
   "spec": {
     "replicas": 1,
+    "selector": {
+      "matchLabels": {
+        "webserver": "[NAME]"
+      }
+    },
     "template": {
       "metadata": {
         "name": "[NAME]",

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/luksa/website-controller
+
+go 1.16

--- a/pkg/website-controller.go
+++ b/pkg/website-controller.go
@@ -43,12 +43,12 @@ func main() {
 
 func createWebsite(website v1.Website) {
 	createResource(website, "api/v1", "services", "service-template.json")
-	createResource(website, "apis/extensions/v1beta1", "deployments", "deployment-template.json")
+	createResource(website, "apis/apps/v1", "deployments", "deployment-template.json")
 }
 
 func deleteWebsite(website v1.Website) {
-	deleteResource(website, "api/v1", "services", getName(website));
-	deleteResource(website, "apis/extensions/v1beta1", "deployments", getName(website));
+	deleteResource(website, "api/v1", "services", getName(website))
+	deleteResource(website, "apis/apps/v1", "deployments", getName(website))
 }
 
 func createResource(webserver v1.Website, apiGroup string, kind string, filename string) {
@@ -84,5 +84,5 @@ func deleteResource(webserver v1.Website, apiGroup string, kind string, name str
 }
 
 func getName(website v1.Website) string {
-	return website.Metadata.Name + "-website";
+	return website.Metadata.Name + "-website"
 }


### PR DESCRIPTION
## Motivation

The application needs some small changes to be able to build it easily whatever the OS used.

## Modifications:

* Adds `Dockerfile.Build` to be able to let Docker build the application  
* Adds an `How to` section to explain how to build the application according to the environment
* Adds the missing `go.mod` file to prevent build error 
* Replaces the deprecated `MAINTAINER` instruction with the proper label
* Updates `deployment-template.json` to match with the current expected format and api version
* Updates `pkg/website-controller.go` to match with the current expected api group
* Adds `website-controller` to `.gitignore` as it is not meant to be added to the git repository

***PS:*** An humble contribution to thank you for your great book 🙏 



